### PR TITLE
Infra: multi-environment Docker (dev/test/prod), compose overlays, multi‑stage Dockerfile, CI, Makefile, README updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, copilot/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Lint and Tests (Compose Overlay)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compose up test overlay
+        run: |
+          docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.test.yml up --abort-on-container-exit --build
+
+      - name: Print Odoo logs on failure
+        if: failure()
+        run: |
+          docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.test.yml logs --no-color || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.test.yml down -v || true
+
+  build-prod:
+    name: Build Production Image
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build prod image
+        run: |
+          docker build --target=prod -t ksef_client:prod -f docker/odoo/Dockerfile .
+
+      # Optional: Vulnerability scanning with Trivy (commented by default)
+      # - name: Run Trivy vulnerability scanner
+      #   uses: aquasecurity/trivy-action@0.24.0
+      #   with:
+      #     image-ref: ksef_client:prod
+      #     format: table
+      #     ignore-unfixed: true
+      #     vuln-type: 'os,library'
+      #     exit-code: '0'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+# Makefile for KSeF Client (Odoo 18)
+
+DOCKER_COMPOSE ?= docker compose
+CBASE := compose/docker-compose.base.yml
+CDEV := compose/docker-compose.dev.yml
+CTEST := compose/docker-compose.test.yml
+CPROD := compose/docker-compose.prod.yml
+
+# Default database name used for shell/update tasks (change as needed)
+DB ?= odoo
+
+.PHONY: help dev-up dev-down dev-restart dev-build logs shell update-module lint format test ci prod-build prod-up prod-down clean clean-volumes rebuild
+
+help:
+	@echo "KSeF Client – common tasks"
+	@echo "\nDev:"
+	@echo "  make dev-up         # start dev stack (build + up)"
+	@echo "  make dev-down       # stop dev stack"
+	@echo "  make dev-restart    # restart dev stack"
+	@echo "  make dev-build      # rebuild dev image"
+	@echo "  make logs           # follow Odoo logs"
+	@echo "  make shell          # open Odoo shell (requires DB: $(DB))"
+	@echo "  make update-module  # -u ksef_client in DB=$(DB)"
+	@echo "  make lint           # run ruff in dev container"
+	@echo "  make format         # run ruff format in dev container"
+	@echo "\nTests/CI:"
+	@echo "  make test           # run test overlay (lint + pytest)"
+	@echo "  make ci             # alias for test"
+	@echo "\nProduction:"
+	@echo "  make prod-build     # build prod image (multi-stage)"
+	@echo "  make prod-up        # run prod overlay"
+	@echo "  make prod-down      # stop prod overlay"
+	@echo "\nCleanup:"
+	@echo "  make clean          # stop all stacks"
+	@echo "  make clean-volumes  # stop and remove volumes"
+	@echo "  make rebuild        # rebuild dev image (no cache)"
+
+# ---- Development ----
+dev-up:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) up -d --build
+
+dev-down:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) down
+
+dev-restart: dev-down dev-up
+
+dev-build:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) build --no-cache odoo
+
+logs:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) logs -f odoo
+
+shell:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo odoo shell --config /etc/odoo/odoo.conf -d $(DB)
+
+update-module:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo odoo -c /etc/odoo/odoo.conf -u ksef_client -d $(DB) --stop-after-init
+
+lint:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo ruff check /mnt/extra-addons/ksef_client
+
+format:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo ruff format /mnt/extra-addons/ksef_client
+
+# ---- Tests / CI ----
+test ci:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CTEST) up --abort-on-container-exit --build ; \
+	RET=$$? ; \
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CTEST) down -v ; \
+	exit $$RET
+
+# ---- Production ----
+prod-build:
+	docker build --target=prod -t ksef_client:prod -f docker/odoo/Dockerfile .
+
+prod-up:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CPROD) up -d --build
+
+prod-down:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CPROD) down
+
+# ---- Cleanup / Utilities ----
+clean:
+	-$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) down || true
+	-$(DOCKER_COMPOSE) -f $(CBASE) -f $(CTEST) down || true
+	-$(DOCKER_COMPOSE) -f $(CBASE) -f $(CPROD) down || true
+
+clean-volumes:
+	-$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) down -v || true
+	-$(DOCKER_COMPOSE) -f $(CBASE) -f $(CTEST) down -v || true
+	-$(DOCKER_COMPOSE) -f $(CBASE) -f $(CPROD) down -v || true
+
+rebuild:
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) build --no-cache odoo && $(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) up -d

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ update-module:
 	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo odoo -c /etc/odoo/odoo.conf -u ksef_client -d $(DB) --stop-after-init
 
 lint:
-	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo ruff check /mnt/extra-addons/ksef_client
+	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo ruff check --no-cache /mnt/extra-addons/ksef_client
 
 format:
 	$(DOCKER_COMPOSE) -f $(CBASE) -f $(CDEV) exec odoo ruff format /mnt/extra-addons/ksef_client

--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ Early scaffold: module structure + authentication client (stub) + smoke tests + 
 ## Project structure
 
 ```
-__manifest__.py        # Metadane modułu Odoo
-models/                # Rozszerzenia modeli Odoo (puste)
-ksef_api_client/       # Warstwa integracji z KSeF
-    auth.py              # Uwierzytelnianie (stub token)
-tests/                 # Testy smoke (Python)
-.github/               # Szablony Issue/PR + instrukcje Copilot
-pyproject.toml         # Konfiguracja Ruff
-CONTRIBUTING.md        # Zasady współpracy
-docker-compose.yml     # Środowisko deweloperskie (PostgreSQL + Odoo)
-docker/odoo/Dockerfile # Obraz Odoo 18 z venv + pip
-requirements.txt       # Dodatkowe zależności Pythona (instalowane do venv)
-config/odoo.conf       # Konfiguracja Odoo (addons_path, DB, logi)
+__manifest__.py        # Odoo module manifest
+models/                # Odoo model extensions (currently empty)
+ksef_api_client/       # KSeF integration layers
+   auth.py              # Authentication (stub token)
+tests/                 # Smoke tests (Python)
+.github/               # Issue/PR templates + Copilot instructions
+pyproject.toml         # Ruff configuration
+CONTRIBUTING.md        # Contribution guidelines
+docker/odoo/Dockerfile # Multi-stage Dockerfile (base/dev/test/prod)
+compose/               # Compose overlays per environment
+requirements.txt       # Python dependencies (installed into venv)
+config/*.conf          # Odoo config files (dev/test/prod)
 ```
 
-## Development setup (Docker)
+## Multi-environment setup (Docker)
 
 ### Prerequisites
 
@@ -31,7 +31,9 @@ Make sure you have Docker and Docker Compose installed on your system:
 - [Install Docker](https://docs.docker.com/get-docker/)
 - [Install Docker Compose](https://docs.docker.com/compose/install/)
 
-### Quick start
+You can use the provided Makefile to simplify commands. All examples below include both Makefile and raw docker compose forms.
+
+### Dev environment (hot-reload)
 
 1. **Clone the repository:**
    ```bash
@@ -40,14 +42,24 @@ Make sure you have Docker and Docker Compose installed on your system:
    ```
 
 2. **Build (first run or after requirements change):**
-   ```bash
-   docker compose build --no-cache odoo
-   ```
+    - Using Makefile (recommended):
+       ```bash
+       make dev-build
+       ```
+    - Or with docker compose overlays:
+       ```bash
+       docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.dev.yml build odoo
+       ```
 
-3. **Start the development environment:**
-   ```bash
-   docker compose up -d
-   ```
+3. **Start the development environment (overlay compose):**
+    - Using Makefile:
+       ```bash
+       make dev-up
+       ```
+    - Or with docker compose overlays:
+       ```bash
+       docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.dev.yml up -d --build
+       ```
 
    This will:
    - Start PostgreSQL 16 database on port 5432
@@ -60,11 +72,68 @@ Make sure you have Docker and Docker Compose installed on your system:
    - Install the `ksef_client` module from the Apps menu
 
 5. **Stop the environment:**
-   ```bash
-   docker compose down
-   ```
+    - Using Makefile:
+       ```bash
+       make dev-down
+       ```
+    - Or with docker compose:
+       ```bash
+       docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.dev.yml down
+       ```
 
-### Running Tests and Linting
+6. **Useful dev helpers:**
+    - Logs
+       ```bash
+       make dev-logs
+       # or
+       docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.dev.yml logs -f odoo
+       ```
+    - Odoo shell
+       ```bash
+       make dev-shell
+       # or
+       docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.dev.yml exec odoo odoo shell --config /etc/odoo/odoo.conf
+       ```
+    - Update/reload module in DB (after Python/XML changes)
+       ```bash
+       make update-module
+       ```
+
+### Test (CI-like) environment
+
+Run ephemeral test container (installs module + runs tests + lint):
+```bash
+docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.test.yml up --abort-on-container-exit --build
+```
+
+Or simply run the tests and lint locally via Makefile:
+```bash
+make test
+make lint
+```
+
+### Production build preview
+
+Build production image only (no dev/test extras):
+```bash
+docker build --target=prod -t ksef_client:prod -f docker/odoo/Dockerfile .
+```
+
+Run production overlay locally (minimal runtime, mounts for filestore and config):
+```bash
+make prod-up
+# or
+docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.prod.yml up -d --build
+```
+
+Stop production overlay:
+```bash
+make prod-down
+# or
+docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.prod.yml down
+```
+
+### Running Tests and Linting (Dev container)
 
 Execute commands inside the Odoo container:
 
@@ -89,18 +158,26 @@ Notes:
    ```
    but remember this won’t persist across rebuilds; add it to `requirements.txt` for permanence.
 
+### Debugging in dev (VS Code attach)
+
+The dev container starts Python with `debugpy` listening on port `5678` (see dev overlay). To attach from VS Code:
+
+1. Install the “Python” extension in VS Code.
+2. Add a launch configuration of type “Python: Attach using Process Id” or “Python: Remote Attach” targeting `localhost:5678`.
+3. Set breakpoints in your module code under `ksef_client/` and attach; requests handled by Odoo will pause accordingly.
+
 ### Troubleshooting
 
 **Port conflicts:**
-If ports 8069 or 5432 are already in use on your system, you can change them in `docker-compose.yml`:
+If ports 8069 or 5432 are already in use on your system, change them in the dev overlay `compose/docker-compose.dev.yml`:
 
 ```yaml
 ports:
   - "8070:8069"  # Change host port from 8069 to 8070
 ```
 
-**Rebuild after dependency changes:**
-If you modify `requirements.txt` or `docker/odoo/Dockerfile`, rebuild the Odoo image:
+**Rebuild after dependency changes (dev):**
+If you modify `requirements.txt` or `docker/odoo/Dockerfile`, rebuild the dev image:
 
 ```bash
 docker compose build --no-cache odoo
@@ -121,7 +198,7 @@ docker compose logs -f odoo
 docker compose down -v
 ```
 
-## Alternative setup (local)
+## Alternative local (without Docker)
 
 ### How to run lint
 
@@ -140,9 +217,24 @@ python -m pytest -q
 
 Use the provided templates: Feature, Bug, Chore. Each task should include context, scope, inputs, outputs, DoD, edge cases, and references.
 
+See `.github/copilot-instructions.md` for the Issue Contract, security rules, and Definition of Done used by Copilot-driven work.
+
+## CI
+
+GitHub Actions workflow `.github/workflows/ci.yml` runs on push/PR:
+- Lint + tests using the test compose overlay
+- Build the production image
+
+You can replicate locally with:
+```bash
+make ci
+```
+
 ## Security
 
 Never commit certificates/keys. Key files are ignored by `.gitignore`. Use mocks and placeholder paths in tests.
+
+In production overlay, provide secrets via Docker/host-level mounts or environment variables. Do not store sensitive data in the repository.
 
 ## Next steps
 
@@ -152,9 +244,10 @@ Never commit certificates/keys. Key files are ignored by `.gitignore`. Use mocks
 
 ## FAQ (Docker)
 
-- Czy mogę zmienić port 8069? Tak – edytuj `docker-compose.yml` (np. `"8070:8069"`).
-- Czy mogę dodać nowe paczki Pythona? Dodaj do `requirements.txt` i przebuduj obraz (`docker compose build --no-cache odoo`).
-- Gdzie są logi? Użyj `docker compose logs -f odoo` lub ustaw własny `logfile` w `config/odoo.conf`.
+- Change port 8069? Edit dev compose overlay (`compose/docker-compose.dev.yml`) ports section.
+- Add new Python packages? Append to `requirements.txt` and rebuild: `docker compose build --no-cache odoo`.
+- Where are logs? `docker compose logs -f odoo` or set `logfile` in the relevant config.
+- How to run only production? Use prod overlay: `docker compose -f compose/docker-compose.base.yml -f compose/docker-compose.prod.yml up -d --build`.
 
 ## License
 

--- a/compose/docker-compose.base.yml
+++ b/compose/docker-compose.base.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: odoo
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoo
+    volumes:
+      - odoo-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U odoo"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  odoo-db-data:
+  odoo-filestore:

--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+
+services:
+  odoo:
+    build:
+      context: ..
+      dockerfile: docker/odoo/Dockerfile
+      target: dev
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8069:8069"
+      - "5678:5678"  # debugpy
+    volumes:
+      - ../:/mnt/extra-addons/ksef_client:ro
+      - ../config/odoo.dev.conf:/etc/odoo/odoo.conf:ro
+      - odoo-filestore:/var/lib/odoo
+    environment:
+      ODOO_ENV: dev
+    command: python -m debugpy --listen 0.0.0.0:5678 -m odoo --config /etc/odoo/odoo.conf --dev=reload,qweb,werkzeug,xml

--- a/compose/docker-compose.prod.yml
+++ b/compose/docker-compose.prod.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+
+services:
+  odoo:
+    build:
+      context: ..
+      dockerfile: docker/odoo/Dockerfile
+      target: prod
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8069:8069"
+    environment:
+      ODOO_ENV: prod
+      DB_HOST: db
+      DB_USER: odoo
+      DB_PASSWORD_FILE: /run/secrets/db_password
+    secrets:
+      - db_password
+    volumes:
+      - odoo-filestore:/var/lib/odoo
+      - ../config/odoo.prod.conf:/etc/odoo/odoo.conf:ro
+    command: odoo --config /etc/odoo/odoo.conf
+
+secrets:
+  db_password:
+    file: ../secrets/db_password.txt

--- a/compose/docker-compose.test.yml
+++ b/compose/docker-compose.test.yml
@@ -13,4 +13,6 @@ services:
       ODOO_ENV: test
     volumes:
       - ../config/odoo.test.conf:/etc/odoo/odoo.conf:ro
-    command: bash -lc "odoo -c /etc/odoo/odoo.conf -i ksef_client --stop-after-init -d test_db && pytest -q /mnt/extra-addons/ksef_client/tests && ruff check /mnt/extra-addons/ksef_client"
+    command: bash -lc "odoo -c /etc/odoo/odoo.conf -i ksef_client --stop-after-init -d test_db \
+      && pytest -q -o cache_dir=/tmp/pytest-cache /mnt/extra-addons/ksef_client/tests \
+      && ruff check --no-cache /mnt/extra-addons/ksef_client"

--- a/compose/docker-compose.test.yml
+++ b/compose/docker-compose.test.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+  odoo:
+    build:
+      context: ..
+      dockerfile: docker/odoo/Dockerfile
+      target: test
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ODOO_ENV: test
+    volumes:
+      - ../config/odoo.test.conf:/etc/odoo/odoo.conf:ro
+    command: bash -lc "odoo -c /etc/odoo/odoo.conf -i ksef_client --stop-after-init -d test_db && pytest -q /mnt/extra-addons/ksef_client/tests && ruff check /mnt/extra-addons/ksef_client"

--- a/config/odoo.dev.conf
+++ b/config/odoo.dev.conf
@@ -1,0 +1,10 @@
+[options]
+db_host = db
+db_port = 5432
+db_user = odoo
+db_password = odoo
+addons_path = /usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
+log_level = debug
+logfile = False
+dev_mode = reload,qweb,werkzeug,xml
+xmlrpc_port = 8069

--- a/config/odoo.prod.conf
+++ b/config/odoo.prod.conf
@@ -1,0 +1,9 @@
+[options]
+db_host = db
+db_port = 5432
+db_user = odoo
+; use DB_PASSWORD_FILE via Docker secrets in compose.prod.yml
+addons_path = /usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
+log_level = warning
+logfile = False
+xmlrpc_port = 8069

--- a/config/odoo.test.conf
+++ b/config/odoo.test.conf
@@ -1,0 +1,9 @@
+[options]
+db_host = db
+db_port = 5432
+db_user = odoo
+db_password = odoo
+addons_path = /usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons
+log_level = info
+logfile = False
+xmlrpc_port = 8069

--- a/docker/odoo/Dockerfile
+++ b/docker/odoo/Dockerfile
@@ -52,6 +52,8 @@ COPY requirements.txt /tmp/requirements.txt
 RUN "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /tmp/requirements.txt \
     && "$VIRTUAL_ENV/bin/pip" install --no-cache-dir ruff pytest
 COPY . /mnt/extra-addons/ksef_client
+# Ensure the odoo user can write caches (pytest/.ruff_cache) during tests
+RUN chown -R odoo:odoo /mnt/extra-addons/ksef_client
 USER odoo
 ENV ODOO_ENV=test
 

--- a/docker/odoo/Dockerfile
+++ b/docker/odoo/Dockerfile
@@ -1,4 +1,5 @@
-FROM odoo:18.0
+ARG ODOO_VERSION=18.0
+FROM odoo:${ODOO_VERSION} AS base
 
 # Switch to root to install system dependencies and create virtual environment
 USER root
@@ -15,10 +16,6 @@ ENV VIRTUAL_ENV=/opt/odoo-venv
 RUN python3 -m venv --system-site-packages "$VIRTUAL_ENV" \
     && "$VIRTUAL_ENV/bin/pip" install --upgrade pip setuptools wheel
 
-# Copy requirements and install into isolated venv (avoid system pip per PEP 668)
-COPY requirements.txt /tmp/requirements.txt
-RUN "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /tmp/requirements.txt
-
 # Ensure system Python used by the Odoo launcher can see venv site-packages via .pth
 RUN bash -lc ' \
     SYS_SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") ; \
@@ -28,6 +25,46 @@ RUN bash -lc ' \
 '
 
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 # Drop privileges
 USER odoo
+
+# -----------------
+# Development stage
+# -----------------
+FROM base AS dev
+USER root
+COPY requirements.txt /tmp/requirements.txt
+RUN "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /tmp/requirements.txt \
+    && "$VIRTUAL_ENV/bin/pip" install --no-cache-dir debugpy ruff
+USER odoo
+ENV ODOO_ENV=dev
+
+# -------------
+# Test stage
+# -------------
+FROM base AS test
+USER root
+COPY requirements.txt /tmp/requirements.txt
+RUN "$VIRTUAL_ENV/bin/pip" install --no-cache-dir -r /tmp/requirements.txt \
+    && "$VIRTUAL_ENV/bin/pip" install --no-cache-dir ruff pytest
+COPY . /mnt/extra-addons/ksef_client
+USER odoo
+ENV ODOO_ENV=test
+
+# ----------------
+# Production stage
+# ----------------
+FROM base AS prod
+USER root
+# Copy only runtime-relevant module files
+COPY ksef_api_client /mnt/extra-addons/ksef_client/ksef_api_client
+COPY models /mnt/extra-addons/ksef_client/models
+COPY __manifest__.py /mnt/extra-addons/ksef_client/
+COPY __init__.py /mnt/extra-addons/ksef_client/__init__.py
+COPY README.md /mnt/extra-addons/ksef_client/README.md
+USER odoo
+ENV ODOO_ENV=prod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests>=2.31.0
 cryptography>=41.0.0
-ruff>=0.1.0


### PR DESCRIPTION
Summary
This PR introduces a complete multi-environment setup for Odoo 18 with:

Docker multi-stage image (base/dev/test/prod) using a dedicated Python venv
Docker Compose overlays for dev/test/prod
Per-environment Odoo configs
Debugging via debugpy in dev
CI workflow to run lint+tests and build the prod image
Makefile with common workflows
Updated README reflecting the new workflow and troubleshooting
It also addresses a prod image import issue by copying [__init__.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) into the module directory and adds sensible Python/Pip env flags.